### PR TITLE
Modify kubeconfig output to not use default-* but instead the cluster name

### DIFF
--- a/modules/kubeconfig/kubeconfig.tf
+++ b/modules/kubeconfig/kubeconfig.tf
@@ -10,36 +10,36 @@ LOCAL_EXEC
 
   provisioner "local-exec" {
     command = <<LOCAL_EXEC
-kubectl config set-cluster default-cluster \
+kubectl config set-cluster cluster-${ var.name } \
   --server=https://${ var.master-elb } \
   --certificate-authority=${ path.cwd }/${ var.ca-pem } &&\
-kubectl config set-credentials default-admin \
+kubectl config set-credentials admin-${ var.name } \
   --certificate-authority=${ path.cwd }/${ var.ca-pem } \
   --client-key=${ path.cwd }/${ var.admin-key-pem } \
   --client-certificate=${ path.cwd }/${ var.admin-pem } &&\
-kubectl config set-context default-system \
-  --cluster=default-cluster \
-  --user=default-admin &&\
-kubectl config use-context default-system
+kubectl config set-context ${ var.name } \
+  --cluster=cluster-${ var.name } \
+  --user=admin-${ var.name } &&\
+kubectl config use-context ${ var.name }
 LOCAL_EXEC
   }
 
   template = <<EOF
-kubectl config set-cluster default-cluster \
+kubectl config set-cluster cluster-${ var.name } \
   --embed-certs=true \
   --server=https://${ var.master-elb } \
   --certificate-authority=${ path.cwd }/${ var.ca-pem }
 
-kubectl config set-credentials default-admin \
+kubectl config set-credentials admin-${ var.name } \
   --embed-certs=true \
   --certificate-authority=${ path.cwd }/${ var.ca-pem } \
   --client-key=${ path.cwd }/${ var.admin-key-pem } \
   --client-certificate=${ path.cwd }/${ var.admin-pem }
 
-kubectl config set-context default-system \
-  --cluster=default-cluster \
-  --user=default-admin
-kubectl config use-context default-system
+kubectl config set-context ${ var.name } \
+  --cluster=cluster-${ var.name } \
+  --user=admin-${ var.name }
+kubectl config use-context ${ var.name }
 
 # Run this command to configure your kubeconfig:
 # eval $(terraform output kubeconfig)


### PR DESCRIPTION
So it doesn't accidentally overwrite existing kubeconfig and supports
multiple clusters
