### PR TITLE
force json output from aws cli

### DIFF
--- a/scripts/init-variables
+++ b/scripts/init-variables
@@ -18,11 +18,11 @@ COREOS_AMI_ID=`curl -s \
   $(printf "http://%s.release.core-os.net/amd64-usr/current/coreos_production_ami_%s_%s.txt" \
     $COREOS_CHANNEL $COREOS_VM_TYPE $AWS_REGION)`
 
-AWS_ACCOUNT_ID=`aws iam get-user \
+AWS_ACCOUNT_ID=`aws iam get-user --output json \
 	| awk '/arn:aws:/{print $2}' \
 	| grep -Eo '[[:digit:]]{12}'`
 
-AWS_REGION_AZS=`aws ec2 describe-availability-zones --region ${AWS_REGION} \
+AWS_REGION_AZS=`aws ec2 describe-availability-zones --region ${AWS_REGION} --output json \
   | jq --raw-output '.AvailabilityZones | map(.ZoneName) | .[]' \
   | xargs \
   | sed -e 's/ /,/g'`


### PR DESCRIPTION
I had some errors because the default output of the aws cli was not set to json for me, I imagine some might have the same problems, so I made sure in the init-variables script that json output would be forced. That's it.
