### PR TITLE
Pass public subnet instead private to worker

### DIFF
--- a/modules.tf
+++ b/modules.tf
@@ -115,7 +115,7 @@ module "worker" {
   name = "${ var.name }"
   region = "${ var.aws.region }"
   security-group-id = "${ module.security.worker-id }"
-  subnet-ids = "${ module.vpc.subnet-ids-private }"
+  subnet-ids = "${ module.vpc.subnet-ids }"
   vpc-id = "${ module.vpc.id }"
 }
 


### PR DESCRIPTION
I was smashing my head into the wall for a day or two, because the ELB's I was setting up, were attached to the wrong subnets, without me noticing, thus not being able to direct traffic to my instances.

This was caused by the fact that the worker is being passed the private subnet ids, instead of the public ones, and while the workers are placed in the public subnet (properly) the subnet ids being passed are private. 

It's strange that there's no error coming form that directly, and works, but hence, here's a very small patch to it.

cheers,
David
