### PR TITLE
Add RKT_OPTS for docker logging 

### DIFF
--- a/modules/worker/cloud-config.tf
+++ b/modules/worker/cloud-config.tf
@@ -117,7 +117,10 @@ coreos:
         Environment="KUBELET_VERSION=${ coreos-hyperkube-tag }"
         Environment="RKT_OPTS=\
         --volume=resolv,kind=host,source=/etc/resolv.conf \
-        --mount volume=resolv,target=/etc/resolv.conf"
+        --mount volume=resolv,target=/etc/resolv.conf \
+        --volume var-log,kind=host,source=/var/log \
+        --mount volume=var-log,target=/var/log"
+        ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --allow-privileged=true \
           --api-servers=http://master.${ internal-tld }:8080 \


### PR DESCRIPTION
I wasn't able to see any kind of logs using fluentd-elasticsearch and elasticsearch. Turned out that there were not log files on the nodes where fluentd was looking to ingest them.  I found that because  kubelet.service on CoreOS is running under rkt engine there are some options that need to be passed.  With this fix I was able to see the logs entries in kibana
