### PR TITLE
fix missing variable for vpc-existing

### DIFF
--- a/modules/vpc-existing/io.tf
+++ b/modules/vpc-existing/io.tf
@@ -3,6 +3,7 @@ variable "azs" {}
 variable "cidr" {}
 variable "name" {}
 variable "region" {}
+variable "hyperkube-tag" {}
 
 variable "id" {}
 variable "gateway-id" {}
@@ -18,3 +19,4 @@ output "id" { value = "${ var.id }" }
 
 output "subnet-ids-public" { value = "${ var.subnet-ids-public }" }
 output "subnet-ids-private" { value = "${ var.subnet-ids-private }" }
+


### PR DESCRIPTION
Missing the `hyperkube-tag` variable for the `vpc-existing` module which causes terraform to complain. Adding it in is confirmed to fix it.
