### PR TITLE
bugfix(etcd) - use count.index for etcd instance subnets

### DIFF
--- a/io.tf
+++ b/io.tf
@@ -26,7 +26,7 @@ variable "coreos-aws" {
   }
 }
 variable "dns-service-ip" { default = "10.3.0.10" }
-variable "etcd-ips" { default = "10.0.10.10,10.0.10.11,10.0.10.12" }
+variable "etcd-ips" { default = "10.0.10.10,10.0.11.10,10.0.12.10" }
 variable "instance-type" {
   default = {
     bastion = "t2.nano"

--- a/modules/etcd/ec2.tf
+++ b/modules/etcd/ec2.tf
@@ -14,7 +14,7 @@ resource "aws_instance" "etcd" {
   }
 
   source_dest_check = false
-  subnet_id = "${ element( split(",", var.subnet-ids-private), 0 ) }"
+  subnet_id = "${ element( split(",", var.subnet-ids-private), count.index ) }"
 
   tags {
     builtWith = "terraform"


### PR DESCRIPTION
etcd instances are currently pinned to a single subnet which means a single AZ.

Pinning them cross AZ
