### PR TITLE
Updated default hosts to match CoreOS OpenSSL documentation

### DIFF
--- a/scripts/init-cfssl
+++ b/scripts/init-cfssl
@@ -63,7 +63,11 @@ function csr {
 EOF
 }
 
-DEFAULT_HOSTS="kubernetes,kubernetes.default,127.0.0.1"
+DNS1="kubernetes"
+DNS2="kubernetes.default"
+DNS3="kubernetes.default.svc"
+DNS4="kubernetes.default.svc.cluster.local"
+DEFAULT_HOSTS="$DNS1,$DNS2,$DNS3,$DNS4,127.0.0.1"
 
 function _chmod {
   CN=$1


### PR DESCRIPTION
Great work with this project! 

I ran into issues with resolving `kubernetes.default.svc` and `kubernetes.default.svc.local` when building an elassticsearch cluster (the same as discussed here [https://github.com/pires/kubernetes-elasticsearch-cluster/issues/27]). I dug into a bit and it looks like the CoreOS OpenSSL documentation includes these DNS names when generating certs ([https://github.com/coreos/coreos-kubernetes/blob/master/Documentation/openssl.md]).

I took a stab at a fix which worked for my cluster. Let me know if this makes sense and would be helpful to include.
