### PR TITLE
added - api server elb idle timeout

### DIFF
--- a/modules/etcd/elb.tf
+++ b/modules/etcd/elb.tf
@@ -1,9 +1,7 @@
 resource "aws_elb" "external" {
   name = "kz8s-apiserver-${replace(var.name, "/(.{0,17})(.*)/", "$1")}"
 
-  subnets = [ "${ split(",", var.subnet-ids-public) }" ]
   cross_zone_load_balancing = false
-  security_groups = [ "${ var.external-elb-security-group-id }" ]
 
   health_check {
     healthy_threshold = 2
@@ -14,6 +12,7 @@ resource "aws_elb" "external" {
   }
 
   instances = [ "${ aws_instance.etcd.*.id }" ]
+  idle_timeout = 3600
 
   listener {
     instance_port = 443
@@ -21,6 +20,9 @@ resource "aws_elb" "external" {
     lb_port = 443
     lb_protocol = "tcp"
   }
+
+  security_groups = [ "${ var.external-elb-security-group-id }" ]
+  subnets = [ "${ split(",", var.subnet-ids-public) }" ]
 
   tags {
     builtWith = "terraform"


### PR DESCRIPTION
- fixes #80
- was default 60s
- set to maximum 3600
