### PR TITLE
Attach EBS volumes to etcd nodes for persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ creation
 * Bastion Host
 * Multi-AZ Auto-Scaling Worker Nodes
 * [NAT Gateway](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html)
+* Cluster state persisted using EBS
+* Automatic snapshotting of all EBS volumes, including dynamically generated persistent volumes
 
 ### CoreOS (1122.3.0, 1185.2.0, 1192.2.0)
 * etcd DNS Discovery Bootstrap
@@ -107,6 +109,7 @@ Terraform v0.7.7
 - Route 53 internal zone for VPC
 - Etcd cluster bootstrapped from Route 53
 - High Availability Kubernetes configuration (masters running on etcd nodes)
+- EBS volumes for etcd cluster with automatic snapshots
 - Autoscaling worker node group across subnets in selected region
 - kube-system namespace and addons: DNS, UI, Dashboard
 

--- a/modules.tf
+++ b/modules.tf
@@ -125,8 +125,6 @@ module "worker" {
 module "snapshot" {
   source = "./modules/snapshot"
   
-  bucket-prefix = "${ var.s3-bucket }"
-  name = "${ var.name }"
   iam-role-snapshot-arn = "${ module.iam.iam-role-snapshot-arn }"
   name = "${ var.name }"
   security-groups = "${ module.security.etcd-id },${ module.security.worker-id }"

--- a/modules.tf
+++ b/modules.tf
@@ -122,6 +122,17 @@ module "worker" {
   worker-name = "general"
 }
 
+module "snapshot" {
+  source = "./modules/snapshot"
+  
+  bucket-prefix = "${ var.s3-bucket }"
+  name = "${ var.name }"
+  iam-role-snapshot-arn = "${ module.iam.iam-role-snapshot-arn }"
+  name = "${ var.name }"
+  security-groups = "${ module.security.etcd-id },${ module.security.worker-id }"
+  subnet-ids = "${ module.vpc.subnet-ids-private },${ module.vpc.subnet-ids-public }"
+}
+
 /*
 module "worker2" {
   source = "./modules/worker"

--- a/modules/etcd/ec2.tf
+++ b/modules/etcd/ec2.tf
@@ -1,3 +1,30 @@
+resource "aws_ebs_volume" "etcd" {
+  count = "${ length( split(",", var.azs) ) }"
+
+  availability_zone = "${ element( split(",", var.azs), 0 ) }"
+
+  type = "gp2"
+  size = 100
+
+  tags {
+    builtWith = "terraform"
+    Cluster = "${ var.name }"
+    depends-id = "${ var.depends-id }"
+    KubernetesCluster = "${ var.name }"
+    Name = "etcd${ count.index + 1 }-${ var.name }"
+    role = "etcd,apiserver"
+    version = "${ var.coreos-hyperkube-tag }"
+  }
+}
+
+resource "aws_volume_attachment" "etcd" {
+  count = "${ length( split(",", var.azs) ) }"
+
+  device_name = "/dev/xvdf"
+  volume_id = "${ element(aws_ebs_volume.etcd.*.id, count.index) }"
+  instance_id = "${ element(aws_instance.etcd.*.id, count.index) }"
+}
+
 resource "aws_instance" "etcd" {
   count = "${ length( split(",", var.etcd-ips) ) }"
 
@@ -32,5 +59,9 @@ resource "aws_instance" "etcd" {
 }
 
 resource "null_resource" "dummy_dependency" {
-  depends_on = [ "aws_instance.etcd" ]
+  depends_on = [
+    "aws_instance.etcd",
+    "aws_ebs_volume.etcd",
+    "aws_volume_attachment.etcd"
+  ]
 }

--- a/modules/iam/io.tf
+++ b/modules/iam/io.tf
@@ -5,5 +5,6 @@ variable "name" {}
 output "depends-id" { value = "${ null_resource.dummy_dependency.id }" }
 output "aws-iam-role-etcd-id" { value = "${ aws_iam_role.master.id }" }
 output "aws-iam-role-worker-id" { value = "${ aws_iam_role.worker.id }" }
+output "iam-role-snapshot-arn" { value = "${ aws_iam_role.snapshot.arn }" }
 output "instance-profile-name-master" { value = "${ aws_iam_instance_profile.master.name }" }
 output "instance-profile-name-worker" { value = "${ aws_iam_instance_profile.worker.name }" }

--- a/modules/iam/snapshot.tf
+++ b/modules/iam/snapshot.tf
@@ -1,0 +1,62 @@
+resource "aws_iam_role" "snapshot" {
+    name = "snapshot"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "snapshot" {
+  name = "snapshot-k8s-${ var.name }"
+
+  policy = <<EOS
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["logs:*"],
+      "Resource": "arn:aws:logs:*:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:Describe*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DetachNetworkInterface",
+        "ec2:DeleteNetworkInterface"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot",
+        "ec2:CreateTags",
+        "ec2:ModifySnapshotAttribute",
+        "ec2:ResetSnapshotAttribute"
+      ],
+      "Resource": ["*"]
+    }
+  ]
+}
+EOS
+
+  role = "${ aws_iam_role.snapshot.id }"
+}

--- a/modules/snapshot/cloudwatch.tf
+++ b/modules/snapshot/cloudwatch.tf
@@ -1,0 +1,11 @@
+resource "aws_cloudwatch_event_rule" "snapshot" {
+  name = "snapshot-${ var.name }"
+  description = "Schedule snapshots of ebs volumes"
+
+  schedule_expression = "rate(2 hours)"
+}
+
+resource "aws_cloudwatch_event_target" "snapshot" {
+  rule = "${ aws_cloudwatch_event_rule.snapshot.name }"
+  arn = "${ aws_lambda_function.snapshot.arn }"
+}

--- a/modules/snapshot/io.tf
+++ b/modules/snapshot/io.tf
@@ -1,0 +1,5 @@
+variable "bucket-prefix" {}
+variable "iam-role-snapshot-arn" {}
+variable "name" {}
+variable "security-groups" {}
+variable "subnet-ids" {}

--- a/modules/snapshot/io.tf
+++ b/modules/snapshot/io.tf
@@ -1,4 +1,3 @@
-variable "bucket-prefix" {}
 variable "iam-role-snapshot-arn" {}
 variable "name" {}
 variable "security-groups" {}

--- a/modules/snapshot/lambda.tf
+++ b/modules/snapshot/lambda.tf
@@ -1,0 +1,37 @@
+resource "aws_lambda_permission" "snapshot" {
+  statement_id = "AllowExecutionFromCloudWatchForSnapshots"
+  action = "lambda:InvokeFunction"
+  function_name = "${ aws_lambda_function.snapshot.arn }"
+  principal = "events.amazonaws.com"
+  source_arn = "${ aws_cloudwatch_event_rule.snapshot.arn }"
+}
+
+resource "aws_lambda_function" "snapshot" {
+  filename = "${ path.module }/../../tmp/snapshot.zip"
+  function_name = "snapshot-${ var.name }"
+  handler = "snapshot.snapshot"
+  runtime = "python2.7"
+  source_code_hash = "${ base64sha256(data.template_file.init.rendered) }"
+
+  role = "${ var.iam-role-snapshot-arn }"
+
+  vpc_config {
+    subnet_ids = ["${ split(",", var.subnet-ids) }"]
+    security_group_ids = ["${ split(",", var.security-groups) }"]
+  }
+}
+
+data "template_file" "init" {
+  template = "${ file("${ path.module }/snapshot.py.tpl") }"
+
+  vars {
+    name = "${ var.name }"
+  }
+}
+
+resource "archive_file" "init" {
+  type = "zip"
+  source_content_filename = "snapshot.py"
+  source_content = "${ data.template_file.init.rendered }"
+  output_path = "${ path.module }/../../tmp/snapshot.zip"
+}

--- a/modules/snapshot/snapshot.py.tpl
+++ b/modules/snapshot/snapshot.py.tpl
@@ -1,0 +1,15 @@
+import boto3
+
+
+ec = boto3.client('ec2')
+
+def snapshot(event, context):
+    volumes = ec.describe_volumes(Filters=[{
+      'Name': 'tag:KubernetesCluster',
+      'Values': ['${ name }'], }])
+
+    for vol in volumes.get('Volumes', []):
+        snap = ec.create_snapshot(VolumeId=vol.get('VolumeId'))
+        ec.create_tags(
+            Resources=[snap.get('SnapshotId')],
+            Tags=vol.get('Tags'))


### PR DESCRIPTION
If you ever lose your etcd cluster for whatever reason, or if you should ever need to restart it, you should be able to recover your state. Mentioned in this issue: https://github.com/kz8s/tack/issues/75

I have a module that will automatically snapshot the drives. If that's at all of interest, happy to commit that as well.
