### PR TITLE
correctly tag worker security group for ELB placement

### DIFF
--- a/modules/security/security.tf
+++ b/modules/security/security.tf
@@ -114,7 +114,7 @@ resource "aws_security_group" "worker" {
   name = "worker-k8s-${ var.name }"
 
   tags {
-    Cluster = "${ var.name }"
+    KubernetesCluster = "${ var.name }"
     Name = "worker-k8s-${ var.name }"
     builtWith = "terraform"
   }


### PR DESCRIPTION
Corrected security group tagging for ELB placement. If there is ever more than one security group on a worker the servicecontroller cannot determine which to place the ELB security group upon type Loadbalancer services. Tagging a single SG with the KubernetesCluster key will fix this.

See --https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/aws/aws.go#L2787
