### PR TITLE
checking existance before creating certs

### DIFF
--- a/modules/pki/user-data.yml
+++ b/modules/pki/user-data.yml
@@ -6,8 +6,42 @@ coreos:
     reboot-strategy: etcd-lock
 
   units:
+  - name: get-service-account-key.service
+    command: start
+    content: |
+      [Unit]
+      Description=Get service-account key file
+      OnFailure=generate-service-account-key.service
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStartPre=-/usr/bin/mkdir --parents /etc/cfssl
+      ExecStart=/usr/bin/rkt run \
+        --net=host \
+        --trust-keys-from-https \
+        --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+        --volume=ssl,kind=host,source=/etc/cfssl,readOnly=true --mount=volume=ssl,target=/etc/cfssl \
+        quay.io/coreos/awscli -- aws s3 cp s3://${ s3-bucket }/service-account-key.pem /etc/cfssl/service-account-key.pem
+
+  - name: get-rootca.service
+    command: start
+    content: |
+      [Unit]
+      ConditionPathExists=/etc/cfssl
+      OnFailure=generate-rootca.service
+      Description=Get rootCA
+      [Service]
+      After=download-cfssl.service
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStart=/usr/bin/rkt run \
+        --net=host \
+        --trust-keys-from-https \
+        --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+        --volume=ssl,kind=host,source=/etc/cfssl,readOnly=true --mount=volume=ssl,target=/etc/cfssl \
+        quay.io/coreos/awscli -- aws s3 cp s3://${ s3-bucket }/ca.pem /etc/cfssl/ca.pem
+
     - name: generate-service-account-key.service
-      command: start
       content: |
         [Unit]
         Description=Generate service-account key file
@@ -38,7 +72,6 @@ coreos:
         ExecStart=/usr/bin/chmod +x /opt/bin/cfssl /opt/bin/cfssljson
 
     - name: generate-rootca.service
-      command: start
       content: |
         [Unit]
         ConditionFileIsExecutable=/opt/bin/cfssl

--- a/modules/pki/user-data.yml
+++ b/modules/pki/user-data.yml
@@ -6,6 +6,36 @@ coreos:
     reboot-strategy: etcd-lock
 
   units:
+  - name: download-cfssl.service
+    command: start
+    content: |
+      [Unit]
+      Description=Download cfssl
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStartPre=/usr/bin/mkdir --parents /opt/bin
+      ExecStartPre=/usr/bin/mkdir --parents /etc/cfssl
+      ExecStartPre=/usr/bin/curl -L -o /opt/bin/cfssl https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
+      ExecStartPre=/usr/bin/curl -L -o /opt/bin/cfssljson https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
+      ExecStart=/usr/bin/chmod +x /opt/bin/cfssl /opt/bin/cfssljson
+
+  - name: cfssl.service
+    command: start
+    content: |
+      [Unit]
+      After=download-cfssl.service
+      ConditionFileIsExecutable=/opt/bin/cfssl
+      Description=Start up cfssl service
+      [Service]
+      ExecStart=/opt/bin/cfssl serve \
+        -address 0.0.0.0 \
+        -ca /etc/cfssl/ca.pem \
+        -ca-key /etc/cfssl/ca-key.pem \
+        -config /etc/cfssl/ca-config.json
+      Restart=always
+      RestartSec=10
+
   - name: get-service-account-key.service
     command: start
     content: |
@@ -27,11 +57,11 @@ coreos:
     command: start
     content: |
       [Unit]
+      After=download-cfssl.service
       ConditionPathExists=/etc/cfssl
       OnFailure=generate-rootca.service
       Description=Get rootCA
       [Service]
-      After=download-cfssl.service
       Type=oneshot
       RemainAfterExit=yes
       ExecStart=/usr/bin/rkt run \
@@ -41,73 +71,43 @@ coreos:
         --volume=ssl,kind=host,source=/etc/cfssl,readOnly=true --mount=volume=ssl,target=/etc/cfssl \
         quay.io/coreos/awscli -- aws s3 cp s3://${ s3-bucket }/ca.pem /etc/cfssl/ca.pem
 
-    - name: generate-service-account-key.service
-      content: |
-        [Unit]
-        Description=Generate service-account key file
-        [Service]
-        Type=oneshot
-        RemainAfterExit=yes
-        ExecStartPre=-/usr/bin/mkdir --parents /etc/cfssl
-        ExecStartPre=/bin/openssl genrsa -out /etc/cfssl/service-account-key.pem 2048 2>/dev/null
-        ExecStart=/usr/bin/rkt run \
-          --net=host \
-          --trust-keys-from-https \
-          --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
-          --volume=ssl,kind=host,source=/etc/cfssl,readOnly=true --mount=volume=ssl,target=/etc/cfssl \
-          quay.io/coreos/awscli -- aws s3 cp /etc/cfssl/service-account-key.pem s3://${ s3-bucket }/
+  - name: generate-service-account-key.service
+    content: |
+      [Unit]
+      Description=Generate service-account key file
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStartPre=-/usr/bin/mkdir --parents /etc/cfssl
+      ExecStartPre=/bin/openssl genrsa -out /etc/cfssl/service-account-key.pem 2048 2>/dev/null
+      ExecStart=/usr/bin/rkt run \
+        --net=host \
+        --trust-keys-from-https \
+        --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+        --volume=ssl,kind=host,source=/etc/cfssl,readOnly=true --mount=volume=ssl,target=/etc/cfssl \
+        quay.io/coreos/awscli -- aws s3 cp /etc/cfssl/service-account-key.pem s3://${ s3-bucket }/
 
-    - name: download-cfssl.service
-      command: start
-      content: |
-        [Unit]
-        Description=Download cfssl
-        [Service]
-        Type=oneshot
-        RemainAfterExit=yes
-        ExecStartPre=/usr/bin/mkdir --parents /opt/bin
-        ExecStartPre=/usr/bin/mkdir --parents /etc/cfssl
-        ExecStartPre=/usr/bin/curl -L -o /opt/bin/cfssl https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
-        ExecStartPre=/usr/bin/curl -L -o /opt/bin/cfssljson https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
-        ExecStart=/usr/bin/chmod +x /opt/bin/cfssl /opt/bin/cfssljson
-
-    - name: generate-rootca.service
-      content: |
-        [Unit]
-        ConditionFileIsExecutable=/opt/bin/cfssl
-        ConditionFileIsExecutable=/opt/bin/cfssljson
-        ConditionPathExists=/etc/cfssl
-        Description=Generate rootca and save to s3
-        [Service]
-        After=download-cfssl.service
-        Type=oneshot
-        RemainAfterExit=yes
-        WorkingDirectory=/etc/cfssl
-        ExecStartPre=/bin/sh -c "\
-          /opt/bin/cfssl gencert -initca ca-csr.json \
-          | /opt/bin/cfssljson -bare ca -"
-        ExecStart=/usr/bin/rkt run \
-          --net=host \
-          --trust-keys-from-https \
-          --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
-          --volume=ssl,kind=host,source=/etc/cfssl,readOnly=true --mount=volume=ssl,target=/etc/cfssl \
-          quay.io/coreos/awscli -- aws s3 cp /etc/cfssl/ca.pem s3://${ s3-bucket }/
-
-    - name: cfssl.service
-      command: start
-      content: |
-        [Unit]
-        After=download-ssl.service
-        ConditionFileIsExecutable=/opt/bin/cfssl
-        Description=Start up cfssl service
-        [Service]
-        ExecStart=/opt/bin/cfssl serve \
-          -address 0.0.0.0 \
-          -ca /etc/cfssl/ca.pem \
-          -ca-key /etc/cfssl/ca-key.pem \
-          -config /etc/cfssl/ca-config.json
-        Restart=always
-        RestartSec=10
+  - name: generate-rootca.service
+    content: |
+      [Unit]
+      ConditionFileIsExecutable=/opt/bin/cfssl
+      ConditionFileIsExecutable=/opt/bin/cfssljson
+      ConditionPathExists=/etc/cfssl
+      Description=Generate rootca and save to s3
+      After=download-cfssl.service
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      WorkingDirectory=/etc/cfssl
+      ExecStartPre=/bin/sh -c "\
+        /opt/bin/cfssl gencert -initca ca-csr.json \
+        | /opt/bin/cfssljson -bare ca -"
+      ExecStart=/usr/bin/rkt run \
+        --net=host \
+        --trust-keys-from-https \
+        --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+        --volume=ssl,kind=host,source=/etc/cfssl,readOnly=true --mount=volume=ssl,target=/etc/cfssl \
+        quay.io/coreos/awscli -- aws s3 cp /etc/cfssl/ca.pem s3://${ s3-bucket }/
 
 write-files:
   - path: /etc/cfssl/ca-csr.json
@@ -142,3 +142,4 @@ write-files:
 
   - path: /etc/cfssl/s3-bucket
     content: ${ s3-bucket }
+


### PR DESCRIPTION
added logic that checks for the availability of the files on s3 before recreating them. If they are on S3 it simply downloads them, without recreation.