### PR TITLE
Monitoring using Grafana via Heapster telemetry into InfluxdB

### DIFF
--- a/addons/heapster/heapster.yml
+++ b/addons/heapster/heapster.yml
@@ -68,6 +68,7 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
+            - --sink=influxdb:http://monitoring-influxdb:8086
         - image: gcr.io/google_containers/addon-resizer:1.7
           name: heapster-nanny
           resources:

--- a/addons/influxdb/default-storage.yaml
+++ b/addons/influxdb/default-storage.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: gp2
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2

--- a/addons/influxdb/grafana-service.yaml
+++ b/addons/influxdb/grafana-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitoring-grafana
+  namespace: kube-system
+  labels: 
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "Grafana"
+spec:
+  # On production clusters, consider setting up auth for grafana, and
+  # exposing Grafana either using a LoadBalancer or a public IP.
+  # type: LoadBalancer
+  ports: 
+    - port: 80
+      targetPort: 3000
+  selector: 
+    k8s-app: influxGrafana
+

--- a/addons/influxdb/influxdb-grafana-controller.yaml
+++ b/addons/influxdb/influxdb-grafana-controller.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+
+metadata:
+  name: influxdb-pvc
+  labels:
+    type: amazonEBS
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 25Gi
+  storageClassName: gp2
+  
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+
+metadata:
+  name: grafana-pvc
+  labels:
+    type: amazonEBS
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 25Gi
+  storageClassName: gp2
+
+---
+
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: monitoring-influxdb-grafana-v4
+  namespace: kube-system
+  labels: 
+    k8s-app: influxGrafana
+    version: v4
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec: 
+  replicas: 1
+  selector: 
+    k8s-app: influxGrafana
+    version: v4
+  template: 
+    metadata: 
+      labels: 
+        k8s-app: influxGrafana
+        version: v4
+        kubernetes.io/cluster-service: "true"
+    spec: 
+      containers: 
+        - image: gcr.io/google_containers/heapster-influxdb-amd64:v1.1.1
+          name: influxdb
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: 100m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 500Mi
+          ports: 
+            - containerPort: 8083
+              name: http
+            - containerPort: 8086
+              name: api
+          volumeMounts:
+          - name: influxdb-persistent-storage
+            mountPath: /data
+        - image: gcr.io/google_containers/heapster-grafana-amd64:v4.0.2
+          name: grafana
+          env:
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          env:
+            # This variable is required to setup templates in Grafana.
+            - name: INFLUXDB_SERVICE_URL
+              value: http://localhost:8086
+              # The following env variables are required to make Grafana accessible via
+              # the kubernetes api-server proxy. On production clusters, we recommend
+              # removing these env variables, setup auth for grafana, and expose the grafana
+              # service using a LoadBalancer or a public IP.
+            - name: GF_AUTH_BASIC_ENABLED
+              value: "false"
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: Admin
+            - name: GF_SERVER_ROOT_URL
+              value: /api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/
+          volumeMounts:
+          - name: grafana-persistent-storage
+            mountPath: /var
+      volumes:
+      - name: influxdb-persistent-storage
+        persistentVolumeClaim:
+          claimName: influxdb-pvc
+      - name: grafana-persistent-storage
+        persistentVolumeClaim:
+          claimName: grafana-pvc

--- a/addons/influxdb/influxdb-service.yaml
+++ b/addons/influxdb/influxdb-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitoring-influxdb
+  namespace: kube-system
+  labels: 
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "influxGrafana"
+spec: 
+  ports: 
+    - name: http
+      port: 8083
+      targetPort: 8083
+    - name: api
+      port: 8086
+      targetPort: 8086
+  selector: 
+    k8s-app: influxGrafana
+


### PR DESCRIPTION
Hi, this is my initial attempt of getting a Grafana dashboard for monitoring, using telemetry from Heapster and storing the data in InfluxDB.
It is currently working but it is not added to the Makefile automation, i will do this if you guys think its a good idea to have this an addon.

You can see it actually working at: http://i.imgur.com/ZUKz32L.png

While working on this i hit a very weird bug were 2 containers on the same pod wouldnt talk to each other via the Service IP and it turns out its a kubelet proxy bug that is fixed by setting the docker0 interface to promisc: https://github.com/kubernetes/kubernetes/issues/20475
The fix was merged in may 22 but i dont think its not on the 1.6 branch yet.

