### PR TITLE
Fix missing quote sign in create-admin-certificate

### DIFF
--- a/scripts/create-admin-certificate
+++ b/scripts/create-admin-certificate
@@ -27,7 +27,7 @@ trap finish EXIT
 # test cfssl connection -- retry until up
 #
 until printf "." && curl -d '{"label":"primary"}' http://localhost:8888/api/v1/cfssl/info &>/dev/null
-do sleep 2.5; done; echo "✓
+do sleep 2.5; done; echo "✓"
 
 function csr {
   cat <<EOF


### PR DESCRIPTION
This will fix error introduced in #167.

Error results in:
```
...
+ trap finish EXIT
+ ssh -o StrictHostKeyChecking=no -i .keypair/kz8s-test.pem -nNT -L 8888:pki.test.kz8s:8888 core@34.250.88.123
scripts/create-admin-certificate: line 44: unexpected EOF while looking for matching `"'
++ finish
++ '[' -z 36305 ']'
++ kill 36305
✓ create admin certificate - SUCCESS
```