### PR TITLE
Certificate Manager

### DIFF
--- a/addons/cert-manager/01-certificate-type.yaml
+++ b/addons/cert-manager/01-certificate-type.yaml
@@ -1,0 +1,7 @@
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+description: "A specification of a Let's Encrypt Certificate to manage."
+metadata:
+  name: "certificate.stable.k8s.psg.io"
+versions:
+  - name: v1

--- a/addons/cert-manager/02-persistent.yaml
+++ b/addons/cert-manager/02-persistent.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+
+metadata:
+  name: kube-cert-manager-pvc
+  labels:
+    type: amazonEBS
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: gp2
+

--- a/addons/cert-manager/03-secret.yaml
+++ b/addons/cert-manager/03-secret.yaml
@@ -1,0 +1,13 @@
+#ROUTE53_ID and ROUTE53_KEY
+#Should be credentials of a IAM user with access to route53 
+#in base64 format:
+#echo -n "TEXT" | base64
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-cert-manager-secret
+type: Opaque
+data:
+  aws_id: ROUTE53_ID
+  aws_key: ROUTE53_KEY

--- a/addons/cert-manager/04-deployment.yaml
+++ b/addons/cert-manager/04-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: kube-cert-manager
+  name: kube-cert-manager
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kube-cert-manager
+      name: kube-cert-manager
+    spec:
+      containers:
+        - name: kube-cert-manager
+          image: rosskukulinski/kube-cert-manager:0.5.0-san
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: kube-cert-manager-secret
+                  key: aws_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: kube-cert-manager-secret
+                  key: aws_key
+          args:
+            #- "-class="
+            - "-data-dir=/var/lib/cert-manager"
+            - "-acme-url=https://acme-v01.api.letsencrypt.org/directory"
+            # NOTE: the URL above points to the staging server, where you won't get real certs.
+            # Uncomment the line below to use the production LetsEncrypt server:
+            #- "-acme-url=https://acme-v01.api.letsencrypt.org/directory"
+            # You can run multiple instances of kube-cert-manager for the same namespace(s), 
+            # each watching for a different value for the 'class' label
+            #- "-class=default"
+            # You can choose to monitor only some namespaces, otherwise all namespaces will be monitored
+            #- "-namespaces=default,test"
+            # If you set a default email, you can omit the field/annotation from Certificates/Ingresses
+            - "-default-email=email@example.org"
+            # If you set a default provider, you can omit the field/annotation from Certificates/Ingresses
+            - "-default-provider=route53"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/cert-manager
+        - name: kubectl-proxy
+          image: bruj0/kubectl-proxy:1.6.2
+          ports:
+            - containerPort: 8001
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: kube-cert-manager-pvc

--- a/addons/cert-manager/05-cert.yaml
+++ b/addons/cert-manager/05-cert.yaml
@@ -1,0 +1,11 @@
+apiVersion: "stable.k8s.psg.io/v1"
+kind: "Certificate"
+metadata:
+  name: "registry"
+  labels:
+    stable.k8s.psg.io/kcm.class: "default"
+spec:
+  domain: "registry.$(CLUSTER_DOMAIN)"
+  email: "email@example.org"
+  provider: "route53"
+  secretName: cert-inc-testbed

--- a/scripts/kubectl-proxy/Dockerfile
+++ b/scripts/kubectl-proxy/Dockerfile
@@ -1,0 +1,4 @@
+FROM lachlanevenson/k8s-kubectl:v1.6.2
+
+EXPOSE 8001
+CMD ["proxy","--address=0.0.0.0"]

--- a/scripts/kubectl-proxy/build-container.sh
+++ b/scripts/kubectl-proxy/build-container.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+docker build -t $1/kubectl-proxy:1.6.2 -t $1/kubectl-proxy:latest $(dirname "$0")
+docker push $1/kubectl-proxy:1.6.2
+docker push $1/kubectl-proxy:latest


### PR DESCRIPTION
This is a certificate manager implemented from https://github.com/kelseyhightower/kube-cert-manager
It request a certificate from Let's Encrypt and authentificates the  domain via Route53 and provides them to the containers in a form of files as in:
```
spec:
  containers:
  - name: my-app
    image: ...
    args:
      - "-tls-cert=/etc/tls/tls.crt"
      - "-tls-key=/etc/tls/tls.key"
    volumeMounts:
      - name: cert
        mountPath: /etc/tls/
  volumes:
    - name: cert
      secret:
        secretName: my-cert-name
```
I created the image for kubectl-proxy because the original project doesn't have a version for 1.6.2, the Dockerfile used is under scripts/kubectl-proxy along with a script to create a new one when the Kubernetes version updates.