### PR TITLE
Place ASG instances across AZs

### DIFF
--- a/modules.tf
+++ b/modules.tf
@@ -156,6 +156,6 @@ module "worker" {
   instance-profile-name = "${ module.iam.instance-profile-name-worker }"
   s3-bucket = "${ module.s3.bucket }"
   security-group-id = "${ module.security.worker-id }"
-  subnet-id = "${ element( split(",", module.vpc.subnet-ids-private), 0 ) }"
+  subnet-ids = "${ module.vpc.subnet-ids-private }"
   vpc-id = "${ module.vpc.id }"
 }

--- a/modules/worker/ec2.tf
+++ b/modules/worker/ec2.tf
@@ -37,7 +37,7 @@ resource "aws_autoscaling_group" "worker" {
   launch_configuration = "${ aws_launch_configuration.worker.name }"
   max_size = "${ var.capacity["max"] }"
   min_size = "${ var.capacity["min"] }"
-  vpc_zone_identifier = [ "${ var.subnet-id }" ]
+  vpc_zone_identifier = [ "${ var.subnet-ids }" ]
 
   tag {
     key = "builtWith"

--- a/modules/worker/io.tf
+++ b/modules/worker/io.tf
@@ -21,7 +21,7 @@ variable "k8s" {
 variable "name" {}
 variable "s3-bucket" {}
 variable "security-group-id" {}
-variable "subnet-id" {}
+variable "subnet-ids" {}
 variable "volume_size" {
   default = {
     ebs = 250


### PR DESCRIPTION
ASG had been hardcoded to a single subnet/availability zone. This passes in all available private VPC subnets/AZs so worker instances will be spread across them (matching the [documentation](https://github.com/kz8s/tack#aws)).